### PR TITLE
GR-576 add optional LIMS entity tag to reports

### DIFF
--- a/queries.js
+++ b/queries.js
@@ -133,10 +133,14 @@ function getAllreports_by_name(req, res, next) {
 }
 
 function createReport(req, res, next) {
+  if (!req.body.hasOwnProperty('lims_entity')) {
+    // property may be null if it is not associated with a LIMS entity (Project, Library, Run, Pool)
+    req.body.lims_entity = null;
+  }
   db
     .one(
-      'insert into report(name, version, category, permitted_parameters)' +
-        'values(${name}, ${version}, ${category}, ${permitted_parameters})' +
+      'insert into report(name, version, category, permitted_parameters, lims_entity)' +
+        'values(${name}, ${version}, ${category}, ${permitted_parameters}, ${lims_entity})' +
         'returning report_id',
       req.body
     )

--- a/routes/index.js
+++ b/routes/index.js
@@ -155,7 +155,7 @@ router.get(
  *         type: string
  *     responses:
  *       200:
- *         description: A list of reports with the given report name or LIMS entity
+ *         description: A list of reports with the given report name or associated with the given LIMS entity
  *         schema:
  *           $ref: '#/definitions/report'
  */

--- a/sql/V3__MISO_entity.sql
+++ b/sql/V3__MISO_entity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE report ADD COLUMN lims_entity text DEFAULT NULL;

--- a/test/sql/V9999__testdata.sql
+++ b/test/sql/V9999__testdata.sql
@@ -4,8 +4,8 @@ VALUES ('jsonReport', '1.0', 'report', '{"instrument":{"type":"s", "required":fa
 Insert INTO report_record (report_id, files_in, report_path, notification_targets, notification_message, parameters)
 VALUES (1, '{"p1"}', '/oicr/data/archive/r1', '{"email":["xluo@oicr.on.ca","seqprobio@oicr.on.ca"]}', 'here is the run report', '{"runName":"170623_D00331_0244_BCB1LMANXX", "instrument":"HiSeq"}');
 
-Insert INTO report (name, version, category, permitted_parameters)
-VALUES ('jsonReport', '1.1', 'report', '{"instrument":{"type":"s", "required":false}, "runName":{"type":"s", "required":true}}');
+Insert INTO report (name, version, category, permitted_parameters, lims_entity)
+VALUES ('jsonReport', '1.1', 'report', '{"instrument":{"type":"s", "required":false}, "runName":{"type":"s", "required":true}}', 'Run');
 
 Insert INTO report_record (report_id, files_in, report_path, notification_targets, notification_message, parameters)
 VALUES (2, '{"p1", "p2"}' ,'/oicr/data/archive/r2','{"email":["xluo@oicr.on.ca","seqprobio@oicr.on.ca"]}', 'here is the run report', '{"runName":"161017_M00146_0050_000000000-AW48L", "instrument":"MiSeq"}');

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -71,6 +71,7 @@ describe('report', function() {
         res.body[0].should.have.property('version');
         res.body[0].should.have.property('category');
         res.body[0].should.have.property('permitted_parameters');
+        res.body[0].should.have.property('lims_entity');
         res.body[0].name.should.equal('jsonReport');
         done();
       });


### PR DESCRIPTION
Some reports are for specific LIMS entities (Project, Library, Pool, Run) and it will be useful to be able to query by LIMS entity.