### PR TITLE
Automate PRs to update GitHub actions to newest major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot includes a default "cooldown" period of 3 days, so updates will only be made after the new version is > 3 days old

Jira ticket:

- [ ] Includes a change file
- [ ] Updates developer documentation
